### PR TITLE
Provide link to guides instead of providing scaling command

### DIFF
--- a/app_development.prolific
+++ b/app_development.prolific
@@ -171,11 +171,11 @@ Scale your app with the CLI
 ### What?
 Your application runs in a container hosted on a Diego Cell. A Cloud Foundry deployment may have many cells distributed among multiple Availability Zones. Diego will automatically balance the applications you deploy across the defined AZs. If an AZ went down (along with your application), Diego would start a new instance of your application in a healthy cell in a different AZ. Depending on demand, you may want to scale your application horizontally (more instances) and/or vertically (more disk & memory).
 
-You already have two instances of dora, but let's bump that up to five.
+You already have two instances of dora. Scale your app _horizontally_ and bump your instances up to five while scaling _vertically_ and set your memory to 512M.
 
 ### How?
 1. Run `cf app dora`
-1. In another terminal buffer, run `cf scale -m 512M -i 5 dora`
+1. Find the appropriate scaling flags in the [guides](https://docs.run.pivotal.io/devguide/deploy-apps/cf-scale.html)
 
 ### Expected Result
 `cf app dora` should show five instances and the disk and memory they are each allotted.


### PR DESCRIPTION
This proposed change is based on Zoe's feedback. She wanted the material to 'force' her to do more research. I think this is a good place for that.