### PR TITLE
Reminder to check GCP quotas

### DIFF
--- a/introduction.prolific
+++ b/introduction.prolific
@@ -13,6 +13,7 @@ It's also a short task list of things you might want to do before Onboarding Wee
 - [ ] Add CF technical overview to participant calendars (ideally Weds or Thurs)
 - [ ] Add Retro to participant calendars (ideally EOD Fri)
 - [ ] For GCP track **only**: Create IAAS account(s). Add participants as Owners.
+- [ ] For GCP track **only**: Ensure GCP quotas for VM instances, external IP addresses and global external IP addresses are sufficient (greater than 24). 
 ---
 Welcome to Onboarding Week!
 ### What?


### PR DESCRIPTION
Feedback from @iainsproat and @terminatingcode onboarding.  Project initially had insufficient quotas.
2 IPs required for bbl up (jumpbox & bosh director), 16 IPs required for CF, and 2 IPs required for concourse, at minimum.