### PR TITLE
Fixes to deploying Concourse with BOSH instructions

### DIFF
--- a/concourse.prolific
+++ b/concourse.prolific
@@ -3,7 +3,7 @@ Deploy Concourse with BOSH
 [Concourse](http://concourse.ci/) is a Pivotal-sponsored, pipeline-based, continuous integration and deployment (CI/CD) system. The "pipelines" are a collection of [three core concepts (jobs, tasks, and resources)](http://concourse.ci/concepts.html) that you'll learn more about in upcoming stories. While CI may call to mind test automation, Pivotal teams use it for so much more than that. Take a stroll around the office and check out the jobs up on the CI screens to get a general idea of how broadly we use it to automate all that is automate-able.
 
 ### How?
-You already have a Bosh Director, a cloud-config, and at least one stemcell, so to spin up a full Concourse deployment all you have to do is prepare your deployment manifest. You can follow **[these instructions](https://github.com/cloudfoundry/bosh-bootloader/blob/master/docs/concourse-gcp.md)** to set it up and Bosh deploy, but as per the yooj there's a small set of additional instructions...
+You already have a Bosh Director, a cloud-config, and at least one stemcell, so to spin up a full Concourse deployment all you have to do is prepare your deployment manifest. Clone this [repo](https://github.com/concourse/concourse-deployment) and follow **[these instructions](https://github.com/cloudfoundry/bosh-bootloader/blob/master/docs/concourse.md)** to set it up and Bosh deploy, but as per the yooj there's a small set of additional instructions...
 
 **Pre-deploy**
 `bbl` only supports one load balancer at a time so in lieu of depriving our CF deployment of its lb, we're going to have Concourse go without. To do this:
@@ -16,6 +16,7 @@ Also, register a new domain on Freenom. Don't do any configuration yet.
  Once `cf -d concourse deploy concourse.yml` is finished running, reserve a static IP address through GCP and attach it to your web VM (you can find its VM CID by running `bosh -d concourse vms`).
 
 Then, on Freenom go to Services > My Domains > Manage Domain > Manage Freenom DNS and create an A record that targets the static IP you just attached to your Concourse web VM.
+In GCP, go to Compute Engine > VM instances > the VM with your concourse deployment, and check 'Allow HTTP traffic' under Firewalls.
 
 ### Troubleshooting
 1. Did you remember to include `http://` in the domain provided as the `external_url` of the `atc` job?

--- a/concourse.prolific
+++ b/concourse.prolific
@@ -13,7 +13,7 @@ You already have a Bosh Director, a cloud-config, and at least one stemcell, so 
 Also, register a new domain on Freenom. Don't do any configuration yet.
 
 **Post-deploy**
- Once `cf -d concourse deploy concourse.yml` is finished running, reserve a static IP address through GCP and attach it to your web VM (you can find its VM CID by running `bosh -d concourse vms`).
+ Once `bosh -d concourse deploy concourse.yml` is finished running, reserve a static IP address through GCP and attach it to your web VM (you can find its VM CID by running `bosh -d concourse vms`).
 
 Then, on Freenom go to Services > My Domains > Manage Domain > Manage Freenom DNS and create an A record that targets the static IP you just attached to your Concourse web VM.
 In GCP, go to Compute Engine > VM instances > the VM with your concourse deployment, and check 'Allow HTTP traffic' under Firewalls.


### PR DESCRIPTION
- fix typo in command
- clarify that the concourse-deployment repo needs to be cloned down
- fix link to bbl concourse instructions
- mention that http traffic needs to be allowed through firewall in GCP