### PR TITLE
Provide uaa secret for pcfdev users

### DIFF
--- a/authorization.prolific
+++ b/authorization.prolific
@@ -30,6 +30,7 @@ Administrators generally create users using the cf CLI, which creates user recor
 
 ### How?
 Following **[these instructions](https://docs.cloudfoundry.org/adminguide/uaa-user-management.html)**, create a new admin user in UAA using the uaac CLI.
+Note: If using pcfDev the client secret needed is: admin-client-secret
 
 ### Expected Result
 Potentially a new UAA user. Potentially an inability to use uaac due to an invalid token.


### PR DESCRIPTION
As new hires going through the onboarding we found it very difficult to find the secret and this would avoid getting stuck for many hours