### PR TITLE
Asg stories

### DIFF
--- a/networking_monitoring.prolific
+++ b/networking_monitoring.prolific
@@ -33,39 +33,6 @@ L: security
 
 ---
 
-Securing your network traffic
-
-### What?
-The `public_networks` (or `all_pcfdev`) security group allows broad access to your CF deployment's network.  A malicious user could likely access internal systems that would not normally be exposed to the public internet. Thus, in a production environment you wouldn't have such open security groups.
-
-**Warning**: On GCP, running an nmap scan against external IP addresses is [not advised](https://nmap.org/book/legal-issues.html).  Please ensure you use the GCP allocated 'internal IP address' for your virtual machine.  You will find the internal IP range allocated to your network from the GCP console.
-
-Let's verify this access and secure it.
-
-### How?
-1. `cf ssh` to an application's container.
-1. Download the **[nmap](https://nmap.org/download.html)** tool (the .tar.bz2 is your best bet, as you can run it as an executable file without requiring root priviledges to install it).
-1. Scan a section of the private network by running:
-`./nmap -v YOUR-INTERNAL-IP/24`
-1.  Find a IP with an open HTTP port (80) and curl that IP address:
-`curl -H "Host: dora.<YOUR-IP>.xip.io" http://<OPEN-IP>`
-1. As an admin, unbind `public_networks` (or `all_pcfdev`) from the running security groups and restart your application.
-1. Run the scan again and try to hit the same IP with the open HTTP port.
-
-### Expected Result
-The initial scan and curl should succeed. After removing the security group and restarting your application curling the open port should fail.
-
-Poke around to see what else you can and can't do without that Security Group. Remember to re-bind it at the end or, if you'd like, try creating and testing your own based on those [most commonly used](https://docs.cloudfoundry.org/adminguide/app-sec-groups.html#typical-groups).
-
-### Resources
-[Nmap Security Scanner](https://nmap.org/)
-[SecTools.Org: Top 125 Network Security Tools](http://sectools.org/)
-[TCP and UDP Ports Explained](https://www.bleepingcomputer.com/tutorials/tcp-and-udp-ports-explained/)
-[Typical Application Security Groups](https://docs.cloudfoundry.org/adminguide/app-sec-groups.html#typical-groups)
-L: security
-
----
-
 Allowing network traffic to other apps
 ### What?
 By default, security groups are configured not to allow app containers to address each other directly.

--- a/networking_monitoring.prolific
+++ b/networking_monitoring.prolific
@@ -82,7 +82,7 @@ But, what if you want your app to be able to establish connections with other pr
 If you need help thinking of a reason you'd want to do this, imagine trying to connect your app to anything that was deployed by BOSH, which mostly deploys to private IPs (which, as we've pointed out in previous stories, are blocked from app containers by default).
 The most common example of this are BOSH-deployed services like [cf-mysql](https://github.com/cloudfoundry/cf-mysql-deployment).
 However, rather than force you to set up another BOSH deployment, let's instead use our existing CF deployment, and see if we can't think of some CF component as a "service" that an app may want to leverage.
-For the sake of this story, let's try to query the router for its list of route (it's a thing you can do!). We'll create our own ASG to allow our app containers to open a connection to the router's private IP.
+For the sake of this story, let's try to query the router for its list of routes (it's a thing you can do!). We'll create our own ASG to allow our app containers to open a connection to the router's private IP.
 
 ### How?
 The basic outline of this workflow is this:

--- a/networking_monitoring.prolific
+++ b/networking_monitoring.prolific
@@ -33,7 +33,7 @@ L: security
 
 ---
 
-Allowing network traffic to other apps
+Allowing network traffic to other apps (AKA Configure container networking policies)
 ### What?
 By default, security groups are configured not to allow app containers to address each other directly.
 For example, if `app1` has IP address 10.255.11.9 and `app2` has IP address 10.255.11.14,
@@ -70,6 +70,65 @@ What happens if you allow access to a port that the app doesn't listen to? Is it
 [Docs: Understanding CF Networking](https://docs.cloudfoundry.org/concepts/understand-cf-networking.html)
 [Docs: Deploy Apps with CF C2C Networking](https://docs.cloudfoundry.org/devguide/deploy-apps/cf-networking.html)
 [Video: CF Networking: All Your Packets are Belong to Us](https://www.youtube.com/watch?v=WrTXd42_m10)
+L: security
+
+---
+
+Allowing network traffic to other, non-app, private IPs (AKA Making custom ASGs)
+### What?
+In the previous story, you uses container networking policies to allow traffic between app containers. Cool beans.
+But, what if you want your app to be able to establish connections with other private IP addresses that aren't apps?
+
+If you need help thinking of a reason you'd want to do this, imagine trying to connect your app to anything that was deployed by BOSH, which mostly deploys to private IPs (which, as we've pointed out in previous stories, are blocked from app containers by default).
+The most common example of this are BOSH-deployed services like [cf-mysql](https://github.com/cloudfoundry/cf-mysql-deployment).
+However, rather than force you to set up another BOSH deployment, let's instead use our existing CF deployment, and see if we can't think of some CF component as a "service" that an app may want to leverage.
+For the sake of this story, let's try to query the router for its list of route (it's a thing you can do!). We'll create our own ASG to allow our app containers to open a connection to the router's private IP.
+
+### How?
+The basic outline of this workflow is this:
+1. Curl the router's `/routes` endpoint from an app container, and see that the connection isn't allowed.
+1. Create and bind an ASG that allows your app container to connect to the IP address of the router.
+1. Try curling the `/routes` endpoint again, and see that you get successful response from the router.
+
+Construct the URL for querying the router
+In order to curl the router's `/routes` endpoint, you'll to get the router's IP address, port, as well as special credentials (username and password) for making this request. Don't worry, you can find all of this in your manifest or vars-store/Credhub.
+- Router IP Address: Run `bosh instances` and look for an instance group called `router` and copy the IP address.
+- Router Status Port: routing-release [sets port 8080 as the default](https://github.com/cloudfoundry/routing-release/blob/develop/jobs/gorouter/spec#L33-L35) -- unless you wrote an ops-file to override the default, you should use this port.
+- Router Status Username: Again, [routing-release has provided a default](https://github.com/cloudfoundry/routing-release/blob/develop/jobs/gorouter/spec#L36-L38). Go with that, most likely.
+- Router Status Password: cf-deployment uses [a BOSH variable called `router_status_password` to configure this password](https://github.com/cloudfoundry/cf-deployment/blob/2118b5d8ac09feed153f6eea552fd561dd6aa999/cf-deployment.yml#L865). The way to fetch this value depends on whether you used Credhub or a vars-store to maintain your credentials. 
+  For Credhub, make sure you've run `eval "$(bbl print-env)"` (don't forget the double quotes!). Then run `credhub find -n router_status_password` to discover the full name of the variable (it will look something like `/bosh-bbl-env-something/cf/router_status_password`). Copy the full name, and run `credhub get -n $FULL_NAME` to get find the password.
+  For vars-store, just grep `router_status_password` from your vars-store
+
+Before creating the ASG:
+1. Make sure you have an app pushed. If don't have one running, `cf push dora -p <PATH_TO_DORA>`.
+1. `cf ssh` to dora's application container, and then run `curl router-status:$ROUTER_PASSWORD@$ROUTER_IP:8080`.
+
+Create and bind an ASG:
+1. Write a file with contents like this:
+  ```
+  [
+    {
+      "protocol": "tcp",
+      "destination": "$ROUTER_IP/32",
+      "ports": "8080",
+      "description": "Allow apps to query router-status"
+    }
+  ]
+  ```
+1. On your command line, run `cf create-security-group router-asg /PATH/TO/ASG_FILE.json`
+1. Bind the ASG to the space that includes your pushed app: `cf bind-security-group router-asg $MY_ORG $MY_SPACE`
+1. Restart dora to allow the ASG to take effect: `cf restart dora`
+
+See if the app container can communicate with the router:
+1. SSH back onto dora, and re-run `curl router-status:$ROUTER_PASSWORD@$ROUTER_IP:8080`
+
+### Expected Result
+The initial curl should fail. After applying the security group, the curl should succeed.
+
+Poke around to see what else you can and can't do with the ASG commands.
+Can you allow access to mutliple ports?
+What happens if you allow access to a port that the router doesn't listen to? Is it give the same error?
+
 L: security
 
 ---


### PR DESCRIPTION
This PR replaces the old `nmap` story -- which didn't really work, and also led people to accidentally nmap the internet -- with a simpler story about using ASGs to access the routers status endpoint.