### PR TITLE
Filter down instructions for GCP resources

### DIFF
--- a/deploy_oss.prolific
+++ b/deploy_oss.prolific
@@ -416,11 +416,11 @@ To do this, we edit our **[cloud config](http://bosh.io/docs/cloud-config.html)*
 To deploy Cloud Foundry you'll be taking advantage of the [cloud config](http://bosh.io/docs/cloud-config.html) that `bbl` generated for you during `bbl up`.
 
 ### How?
-Check your CPU quota by navigating to Home > IAM & Admin > Quotas. If you have more than 24 us-east1 CPUs available, then there's no need to change the cloud config but knowing how to do so for the future is a good thing, so read on.
+Check your CPU quota in the GCP Console by navigating to Home > IAM & Admin > Quotas.  There are a lot of line items in this list, you can trim it down by setting the `Metric` drop-down to `CPUs` (only) and the setting the `Location` drop-down to `US-East1` (only).  Currently, we have quite a few more CPUs than the bare minimum of 24.  This means we do not need to change the cloud config but knowing how to do so for the future is a good thing, so read on.
 
 Run `bosh cloud-config > cloud-config.yml`
 
-Then, open the new `cloud-config.yml` file in an editor and locate `compilation: workers:`. If you have a 24 CPU quota on GCP, reduce the number of compilation machines to two; if you have something way higher than 24 CPU leave it alone.
+Then, open the new `cloud-config.yml` file in an editor and locate `compilation: workers:`. If you were to have 24 CPU quota on GCP, reduce the number of compilation machines to 2; if you have something way higher than 24 CPU (as we have), leave it alone.
 
 Then, if you edited the file, run `bosh update-cloud-config cloud-config.yml` to apply your changes.
 


### PR DESCRIPTION
This is a follow-up on issue 226:  Not only are we
telling them which column to look for, also instruct
them to filter the lines down.