### PR TITLE
Link to correct cfcr deployment docs

### DIFF
--- a/projects.prolific
+++ b/projects.prolific
@@ -121,7 +121,7 @@ Deploy CF flavored Kubernetes, with the aide of BOSH.
 https://www.cloudfoundry.org/container-runtime/
 https://github.com/cloudfoundry/docs-cfcr
 https://content.pivotal.io/slides/cloud-foundry-container-runtime-cfcr-production-kubernetes
-http://engineering.pivotal.io/post/deploy-kubernetes-cfcr/
+https://github.com/cloudfoundry-incubator/kubo-release
 
 ---
 


### PR DESCRIPTION
The old link is to a deprecated method of setting up CFCR. The new method is documented at https://github.com/cloudfoundry-incubator/kubo-release.