### PR TITLE
Fixes issue 254: Rewrite the instructions for Bosh Deploy

### DIFF
--- a/deploy_oss.prolific
+++ b/deploy_oss.prolific
@@ -58,7 +58,7 @@ The `gcloud` CLI manages authentication, local configuration, developer workflow
 This is another "fun-sized" story (you know you'll miss them once you hit the 6-hour ones....)
 
 ### How?
-Follow **[these instructions](https://cloud.google.com/sdk/downloads)** to install Google Cloud SDK on your workstation.
+Follow **[these instructions](https://cloud.google.com/sdk/docs/downloads-interactive)** to install Google Cloud SDK on your workstation.
 
 Once you've done that, run `gcloud init` in your terminal.
 
@@ -486,17 +486,22 @@ Deploy CF using BOSH + cf-deployment
 The standard cf-deployment is fairly hefty, so we're going to scale ours down to a more reasonable size using an [operations file](https://bosh.io/docs/cli-ops-files.html) that reduces the number of VMs we deploy. Using an operations file to make small adjustments like this means we can edit our deployment without changing the core `cf-deployment.yml` manifest.
 
 ### How?
-Clone the **[cf-deployment repo](https://github.com/cloudfoundry/cf-deployment)** and the **[bosh-deployment-repo](https://github.com/cloudfoundry/bosh-deployment)** to your workstation, then follow [these instructions](https://github.com/cloudfoundry/cf-deployment/blob/master/deployment-guide.md) You've already done many of the early steps, up to Step 6 (uploading the cloud config). You've also already done the "Upload a stemcell" step, so just double-check that the versions still line up.   
+Clone the **[cf-deployment repo](https://github.com/cloudfoundry/cf-deployment)** to your workstation (we assume you put it in `~/workspace`, next to your onboarding directory).
+```
+bosh -d cf deploy ../cf-deployment/cf-deployment.yml -v system_domain=<YOUR_DOMAIN> --non-interactive -o ../cf-deployment/operations/use-compiled-releases.yml -o ../cf-deployment/operations/scale-to-one-az.yml
+```
 
-Add `-o operations/scale-to-one-az.yml` to the deploy command. This ops-file will cut your deployment size in half, so you'll deploy faster (and your deployment will cost less money).
+This one step is part of a step-by-step procedure listed in [these instructions](https://github.com/cloudfoundry/cf-deployment/blob/master/deployment-guide.md), but this backlog has already set you up with everything you need.
 
-If you want to speed up the deploy, you can also add `-o operations/use-compiled-releases.yml`, to skip compiling all of your releases.
+Let's discuss the options we used:
+- We added `--non-interactive` flag. Normally, after initial preprocessing steps, BOSH will present the "manifest changes", differences between the currently-deployed manifest (currently nothing) and the deploying manifest. Without this flag, you'll be prompted ~5 minutes after the `bosh deploy` command to approve the manifest changes.
+- We added `-o operations/use-compiled-releases.yml`, to skip compiling all of your releases.
+- We added `-o operations/scale-to-one-az.yml` to the deploy command. This ops-file will cut your deployment size in half, so you'll deploy faster (and your deployment will cost less money).
 
-We also recommend you use the `--non-interactive` flag. Normally, after initial preprocessing steps, BOSH will present the "manifest changes", differences between the currently-deployed manifest (currently nothing) and the deploying manifest. Without this flag, you'll be prompted ~5 minutes after the `bosh deploy` command to approve the manifest changes.
 
 ### Expected Result
 Wait for the BOSH deploy to complete. It will take a while...like 20 minutes or so...you might want to check out the next "intermission" story, or go grab a snack, or play game of ping pong.
-Once the deploy is finished, run `bosh vms`. All of them should have a status of "running".
+Once the deploy is finished, run `bosh vms`. All of them (currently 15) should have a status of "running".
 
 ### Resources
 [Docs: What is a BOSH release?](https://bosh.io/docs/release.html)


### PR DESCRIPTION
- Instead of referring to the cf-deployment docs, list the one command they have to run.
- Also update download URL for `gcloud`