### PR TITLE
Adds missing param to cleanup, clarifies bosh deploy

### DIFF
--- a/bosh_troubleshooting.prolific
+++ b/bosh_troubleshooting.prolific
@@ -31,10 +31,11 @@ Ops files are a way for operators to make edits to a deployment manifest in a re
   - **Append** to a list
 
 ### How?
+1. Get your current bosh manifest by running `bosh -d cf manifest > /tmp/cf.yml`
 1. Write an ops-file called `scale-diego-cells.yml` that will scale up the number of Diego cells to 3 instances. See if you can use the ops-file documentation and examples to figure out how. (Some hints: think about which spot in the manifest you want to update. What operation do you need to carry out?)
 1. Vet your changes by running `bosh interpolate`:
   ```
-  bosh interpolate cf-deployment.yml \
+  bosh interpolate /tmp/cf.yml \
   -o ... [any other ops-files you used to deploy orginally] ... \
   -o scale-diego-cells.yml \
   -v system_domain=$SYSTEM_DOMAIN
@@ -42,7 +43,7 @@ Ops files are a way for operators to make edits to a deployment manifest in a re
   Dig around in the output, and see if it matches what you expected. Specifically, is the instance count for the `diego-cell` instance group set to what you wanted?
 1. Deploy:
   ```
-  bosh deploy cf-deployment.yml \
+  bosh deploy /tmp/cf.yml \
   -o ... [any other ops-files you used to deploy originally] ... \
   -o scale-diego-cells.yml \
   -v system_domain=$SYSTEM_DOMAIN

--- a/clean_up.prolific
+++ b/clean_up.prolific
@@ -13,7 +13,7 @@ L: gcp
 Destroy the BOSH director
 
 ### How?
-Run `bbl destroy` to tear down your BOSH director. Bye, Felicia!
+Run `bbl destroy --gcp-service-account-key=service-account.key.json` to tear down your BOSH director. Bye, Felicia!
 L: gcp
 
 ---
@@ -26,7 +26,7 @@ If you created any other GCP resources please tear those down as well.
 ### How?
 If you deployed the environment via `bbl`:
 - Run `bosh -d <DEPLOYMENT-NAME> delete-deployment` to delete all deployed VMs
-- `bbl destroy` to delete the Director and any IaaS resources
+- `bbl destroy --gcp-service-account-key=service-account.key.json` to delete the Director and any IaaS resources
 
 If you deployed the environment via Ops Manager:
 - Click Username dropdown in top-right > Settings > Advanced > Delete this Installation


### PR DESCRIPTION
## SF CF Onboarding 2019 Feedback

+ Adds the missing required parameter to `bbl destroy` like `--gcp-service-account-key=service-account.key.json`

+ Instructs to use latest bosh manifest when re-deploying rather than the original cf-deployment.yml manifest. If you don't do this, you end up in a situation where some of the previous network policy changes are reverted. It also is really confusing when bosh prints out the manifest changes and it's way more than the intended change (i.e. `instances: 3`). 