### PR TITLE
Handle the Apple Silicon (M1) chip

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2086
+# SC2086: Disable double quote expansion.
 
 set -eu
 
@@ -7,7 +9,13 @@ if [ "$#" -lt 1 ]; then
   exit 1
 fi
 
-docker build -t pivotal-cf-onboarding .
-docker run -v "$PWD:/onboarding" -w /onboarding pivotal-cf-onboarding go run generate-tracker-csv.go "${1}"
+PLATFORM=
+if [ "$(uname -m)" == "arm64" ]; then
+  echo "Building for ARM64"
+  PLATFORM="--platform linux/amd64"
+fi
+
+docker build ${PLATFORM} -t pivotal-cf-onboarding .
+docker run ${PLATFORM} -v "$PWD:/onboarding" -w /onboarding pivotal-cf-onboarding go run generate-tracker-csv.go "${1}"
 
 echo -e "\n\nGenerated output CSV at '$PWD/onboarding-tracker.csv'"

--- a/deploy_oss.prolific
+++ b/deploy_oss.prolific
@@ -20,6 +20,8 @@ Install or update the following dependencies on your local machine:
 * **Golang** (run `brew install go`)
 * **Terraform** is a tool for building, changing, and versioning infrastructure safely and efficiently (run `brew install terraform`)
 
+**NOTE:** If you are on an Apple Silicon machine (i.e. M1), you will need to use Rosetta to install the following homebrew dependencies. [This Article](https://community.pivotal.io/s/article/The-x86-64-architecture-is-required-unsatisfied-requirement-failed-this-build-error-when-installing-cf-CLI-on-an-M1-MacBook?language=en_US) describes how to do this.
+
 The following dependencies can be installed through the Cloud Foundry [homebrew tap](https://github.com/cloudfoundry/homebrew-tap)
 * **BOSH CLI V2** is written in Golang (the original was written in Ruby) and has an expanded feature set (`brew tap cloudfoundry/tap && brew install cloudfoundry/tap/bosh-cli`)
 * **bbl** is a tool for paving infrastructure in your desired IAAS as well as deploying a BOSH director (run `brew install bbl`)


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/pivotal/cf-onboarding/pulls) for the same update/change?


## New Stories:
* [x] Have you checked to ensure the new stories don't significantly overlap with other stories in the backlog?
* [x] Have you applied the appropriate label for the stories?

1. How will the new stories enrich the CF-onboarding curriculum?
2. Brief description of the stories

## Updates to Existing Stories:
**Proposed Changes**
* `bbl` and `cf-cli` do not support M1 chip. Add link to describe how to dual install homebrew and using rosetta

## New/Updated Scripts:
**Proposed Changes**
* Prolific doesn't support M1 chip, Adding `--platform linux/amd64` to prolific's docker commands
* 

## Updates to Docs:
**Proposed Changes**
