### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/app_development.prolific
+++ b/app_development.prolific
@@ -267,7 +267,7 @@ Run `watch cf app dora`.
 
 In another buffer, restart a specific instance of dora using `cf restart-app-instance APP_NAME INSTANCE_INDEX`.
 
-Alternatively, you can also kill a specific instance of dora using `cf curl /v2/apps/APP_GUID/instances/0 -d '' -X DELETE` (reading the `cf curl` help content and [API Docs: Terminate the running app instance at the given index](http://apidocs.cloudfoundry.org/253/apps/terminate_the_running_app_instance_at_the_given_index.html) may clarify some things).
+Alternatively, you can also kill a specific instance of dora using `cf curl /v2/apps/APP_GUID/instances/0 -d '' -X DELETE` (reading the `cf curl` help content and [API Docs: Terminate the running app instance at the given index](http://v2-apidocs.cloudfoundry.org/apps/terminate_the_running_app_instance_at_the_given_index.html) may clarify some things).
 
 ### Expected Result
 You should see the correct instance of your app dying and recovering.
@@ -400,7 +400,7 @@ Using the API directly lets users do as much or as little of `cf push` as they l
 
 ### Resources
 [V3 API docs](http://v3-apidocs.cloudfoundry.org)
-[V2 API docs](https://apidocs.cloudfoundry.org/)
+[V2 API docs](https://v2-apidocs.cloudfoundry.org/)
 [Component: Cloud Controller](https://docs.cloudfoundry.org/concepts/architecture/cloud-controller.html)
 [Using Experimental of CLI Commands](https://docs.cloudfoundry.org/devguide/v3-commands.html)
 


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)